### PR TITLE
Migration to Manifest V3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "14.17.0"
+          node-version: "19.2.0"
       - name: install
         run: npm install
       - name: build

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "arxiv2notion",
   "description": "easy-to-use arXiv clipper for notion.so",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "icons": {
     "128": "icon128.png"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -16,15 +16,13 @@
     "page": "options.html",
     "open_in_tab": false
   },
-  "permissions": ["tabs", "bookmarks"],
+  "permissions": ["tabs", "bookmarks", "storage"],
   "host_permissions": [
     "<all_urls>",
     "*://api.notion.com/*",
-    "*://www.notion.so/*",
-    "storage",
-    "tabs"
+    "*://www.notion.so/*"
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; 'unsafe-eval'; object-src 'self'"
+    "extension_pages": "script-src 'self'; object-src 'self'"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "arxiv2notion",
   "description": "easy-to-use arXiv clipper for notion.so",
   "version": "0.0.1",
   "icons": {
     "128": "icon128.png"
   },
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html",
     "default_icon": {
       "128": "icon128.png"
@@ -16,12 +16,15 @@
     "page": "options.html",
     "open_in_tab": false
   },
-  "permissions": [
+  "permissions": ["tabs", "bookmarks"],
+  "host_permissions": [
     "<all_urls>",
     "*://api.notion.com/*",
     "*://www.notion.so/*",
     "storage",
     "tabs"
   ],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; 'unsafe-eval'; object-src 'self'"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arxiv2notion",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "easy-to-use arXiv clipper",
   "author": "denkiwakame <denkivvakame@gmail.com>",
   "license": "MIT License",


### PR DESCRIPTION
- https://developer.chrome.com/docs/extensions/migrating/checklist/
- https://developer.chrome.com/docs/extensions/migrating/

> Manifest V3 is supported generally in Chrome 88 or later. For extension features added in later Chrome versions, see the [API reference documentation](https://developer.chrome.com/docs/extensions/reference/) for support information. If your extension requires a specific API, you can specify [a minimum chrome version](https://developer.chrome.com/docs/extensions/mv3/manifest/minimum_chrome_version/) in the manifest file.
