### PR TITLE
OpenReview URL support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "arxiv2notion",
   "description": "easy-to-use arXiv clipper for notion.so",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "icons": {
     "128": "icon128.png"
   },
@@ -16,8 +16,12 @@
     "page": "options.html",
     "open_in_tab": false
   },
-  "permissions": ["activeTab", "storage"],
-  "host_permissions": ["*://api.notion.com/*", "*://www.notion.so/*"],
+  "permissions": ["tabs", "activeTab", "storage"],
+  "host_permissions": [
+    "*://api.notion.com/*",
+    "*://www.notion.so/*",
+    "*://openreview.net/*"
+  ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arxiv2notion",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "easy-to-use arXiv clipper",
   "contributors": [
     "denkiwakame<denkivvakame@gmail.com>",

--- a/src/js/notion.js
+++ b/src/js/notion.js
@@ -108,6 +108,7 @@ export default class Notion {
     const paperUrl = data.url;
     const authorsFormatted = data.authors.join(', ');
     const published = data.published;
+    const publisher = data.publisher;
     const comment = data.comment;
     const authors = authorsFormatted.split(', ');
     const authorsMultiSelect = authors.map((author) => {
@@ -129,7 +130,7 @@ export default class Notion {
         Publisher: {
           id: 'conference',
           type: 'select',
-          select: { name: 'arXiv' },
+          select: { name: publisher },
         },
         URL: {
           id: 'url',

--- a/src/js/notion.js
+++ b/src/js/notion.js
@@ -207,7 +207,7 @@ export default class Notion {
         body: JSON.stringify(body),
       });
       const data = await res.json();
-      data.results.forEach((result) => {
+      data.results?.forEach((result) => {
         const option = `<option value=${result.id}>${result.title[0].text.content}</option>`;
         document
           .getElementById('js-select-database')


### PR DESCRIPTION
- [x] :bug: "tabs" permission is required to access tab.url (see: https://developer.chrome.com/docs/extensions/reference/api/tabs?hl=ja)
  - Fixes #10 
- [x] OpenReview URL support (experimental)
  - Directly retrieve metadata from the page (paper information is unavailable in OpenReview API V2)