### PR TITLE
Add support for the old style arxiv ID

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -12,7 +12,8 @@ UIKit.use(Icons);
 
 const TEST_URL = 'https://arxiv.org/abs/2308.04079';
 const ARXIV_API = 'http://export.arxiv.org/api/query/search_query';
-
+const ARXIV_ID_REGEX = /\d+\.\d+/; // new id format, e.g. 2404.16782
+const ARXIV_OLD_ID_REGEX = /(\w|\-)+\/\d+/; // old id format, e.g. hep-th/0702063
 class UI {
   constructor() {
     this.setupProgressBar();
@@ -102,7 +103,7 @@ class UI {
     if (this.isOpenReviewUrl(url)) return this.getOpenReviewInfo(url);
   }
   parseArXivId(str) {
-    const paperId = str.match(/\d+.\d+/);
+    const paperId = str.match(ARXIV_ID_REGEX)?.[0] || str.match(ARXIV_OLD_ID_REGEX)?.[0];
     return paperId;
   }
 
@@ -135,7 +136,7 @@ class UI {
     console.log(xmlData);
 
     const entry = xmlData.querySelector('entry');
-    const id = entry.querySelector('id')?.textContent.match(/\d+\.\d+/)?.[0];
+    const id = this.parseArXivId(entry.querySelector('id')?.textContent);
     const paperTitle = entry.querySelector('title').textContent;
     const abst = entry.querySelector('summary').textContent;
     const authors = Array.from(entry.querySelectorAll('author')).map(

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -12,8 +12,6 @@ UIKit.use(Icons);
 
 const TEST_URL = 'https://arxiv.org/abs/2308.04079';
 const ARXIV_API = 'http://export.arxiv.org/api/query/search_query';
-const ARXIV_ID_REGEX = /\d+\.\d+/; // new id format, e.g. 2404.16782
-const ARXIV_OLD_ID_REGEX = /(\w|\-)+\/\d+/; // old id format, e.g. hep-th/0702063
 class UI {
   constructor() {
     this.setupProgressBar();
@@ -102,10 +100,9 @@ class UI {
     if (this.isArxivUrl(url)) return this.getArXivInfo(url);
     if (this.isOpenReviewUrl(url)) return this.getOpenReviewInfo(url);
   }
-  parseArXivId(str) {
-    const paperId = str.match(ARXIV_ID_REGEX)?.[0] || str.match(ARXIV_OLD_ID_REGEX)?.[0];
-    return paperId;
-  }
+  // ref: https://info.arxiv.org/help/arxiv_identifier.html
+  // e.g. (new id format: 2404.16782) | (old id format: hep-th/0702063)
+  parseArXivId = (str) => str.match(/(\d+\.\d+$)|((\w|-)+\/\d+$)/)?.[0];
 
   setFormContents(paperTitle, abst, comment, authors) {
     document.getElementById('js-title').value = paperTitle;


### PR DESCRIPTION
## What?
I've added support for the old style arxiv ID. This is one of the suggestions I made in Issue https://github.com/denkiwakame/arxiv2notion/issues/14.

## Why?
These changes enable this app to load old arxiv papers before 2007, whose ID format is different from the current one.
(see also https://info.arxiv.org/help/arxiv_identifier.html)

## How?
I added another regex for the old ID format (e.g. hep-th/0702063).

## Testing?
The changes have been tested in my local environment and are functioning as expected.

## Screenshots (optional)
<img width="692" alt="スクリーンショット 2024-04-27 3 30 28" src="https://github.com/denkiwakame/arxiv2notion/assets/43782664/2f70e644-15b6-440d-8fc9-4ec735cd12d8">

