### PR TITLE
Fix arxiv parser

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,35 @@
+## 🔄 Changes
+
+<!-- Describe the changes you've made -->
+
+## ⚠️ Breaking Changes
+
+<!-- Select "Yes" if there are any breaking changes and provide details -->
+
+- [ ] None
+- [ ] Yes
+  - **Details:**
+
+## 🎯 Motivation
+
+<!-- Explain why this change is necessary and what problem it solves -->
+
+## 🔍 Reproduction Steps
+
+<!-- Provide specific commands or steps to reproduce/verify the changes -->
+
+```bash
+# Example:
+# npm run build
+# npm run dev
+# npm run lint
+# npm run pack
+```
+
+## ✅ Results
+
+<!-- If applicable, include key results, metrics, or experimental findings -->
+
+## 📝 Additional Notes
+
+<!-- Any additional information that reviewers should know -->

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '14.17.0'
+          node-version: '24.8.0'
       - name: install
         run: npm install
       - name: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,58 @@
 # CHANGELOG
+
 All notable changes to this repository will be documented in this file.
 
-## [1.4.0] - 2024-07-18
+## [1.4.1] - 2024-12-19
+
+### Added
+
+- Support for www.arxiv.org URLs in addition to arxiv.org
+- Fixed arXiv API request with proper CORS headers
+- Additional host permissions for arxiv.org and www.arxiv.org domains
+
 ### Fixed
+
+- Updated arXiv API endpoint from HTTP to HTTPS for security
+- Improved error handling for arXiv API requests with status code logging
+- Enhanced URL detection to support both arxiv.org and www.arxiv.org formats
+
+## [1.4.0] - 2024-07-18
+
+### Fixed
+
 - updates for the latest Notion dashboard @denkiwakame [PR#19](https://github.com/denkiwakame/arxiv2notion/pull/19)
 
 ## [1.3.0] - 2024-05-28
+
 ### Added
+
 - 🚀 **New Feature:** ACL Anthology URL support (experimental) [PR#16](https://github.com/denkiwakame/arxiv2notion/pull/16)
 - 🚀 **New Feature:** support for old arXiv identifier [PR#15](https://github.com/denkiwakame/arxiv2notion/pull/15) @aralsea
 
 ## [1.2.0] - 2024-01-17
+
 ### Added
+
 - 🚀 **New Feature:** OpenReview URL support (experimental) [PR#11](https://github.com/denkiwakame/arxiv2notion/pull/11) [PR#12](https://github.com/denkiwakame/arxiv2notion/pull/12)
+
 ### Changed
+
 - restrict host_permission [PR#10](https://github.com/denkiwakame/arxiv2notion/pull/10)
 
 ## [1.1.0] - 2024-01-10
+
 ### Added
+
 - 🚀 **New Feature:** check duplicated entry [PR#9](https://github.com/wangjksjtu/arxiv2notionplus/issues/1)
+
 ### Changed
+
 - Migration to Notion API version (2022-06-28) [PR#8](https://github.com/denkiwakame/arxiv2notion/pull/8)
 
 ## [1.0.0] - 2024-01-08
+
 ### Added
+
 - integrates [arxiv2notionplus](https://github.com/wangjksjtu/arxiv2notionplus/issues/1) [PR#6](https://github.com/denkiwakame/arxiv2notion/pull/6)
   - add publication date for easier tracking @wangjksjtu
   - add comment parser for quick access to the potential project homepage or code link (if available) @wangjksjtu
@@ -33,13 +62,17 @@ All notable changes to this repository will be documented in this file.
 - Linter / Formatter @denkiwakame
 
 ### Changed
+
 - Replace the author field from `text` to `multi-select` to fully leverage the search/filter in notion @wangjksjtu
 - Release a public notion database/table [here](https://denkiwakame.notion.site/597cdd58bded4375b1cbe073b2ed6f5d?v=63fcbfda57824b239b66e52dde841cdf) @denkiwakame
 - Update UI to improve the navigation to the button @denkiwakame
 
 ### Fixed
+
 - Migration to Manifest V3 @denkiwakame [PR#7](https://github.com/denkiwakame/arxiv2notion/pull/7)
 
 ## [0.0.1] - 2021-06-07
+
 ### Added
+
 - initial release from @denkiwakame

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,9 @@
     "*://export.arxiv.org/*",
     "*://www.notion.so/*",
     "*://openreview.net/*",
-    "*://aclanthology.org/*"
+    "*://aclanthology.org/*",
+    "*://arxiv.org/*",
+    "*://www.arxiv.org/*"
   ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
   "permissions": ["tabs", "storage"],
   "host_permissions": [
     "*://api.notion.com/*",
+    "*://export.arxiv.org/*",
     "*://www.notion.so/*",
     "*://openreview.net/*",
     "*://aclanthology.org/*"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "arxiv2notion",
   "description": "easy-to-use arXiv clipper for notion.so",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "icons": {
     "128": "icon128.png"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arxiv2notion",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arxiv2notion",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT License",
       "dependencies": {
         "mustache": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arxiv2notion",
-  "version": "1.1.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arxiv2notion",
-      "version": "1.1.0",
+      "version": "1.4.0",
       "license": "MIT License",
       "dependencies": {
         "mustache": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arxiv2notion",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "easy-to-use arXiv clipper",
   "contributors": [
     "denkiwakame<denkivvakame@gmail.com>",

--- a/src/js/parsers.js
+++ b/src/js/parsers.js
@@ -19,15 +19,21 @@ class URLParser {
 }
 
 const arXivParser = async (url) => {
-  const ARXIV_API = 'http://export.arxiv.org/api/query/search_query';
+  const ARXIV_API = 'https://export.arxiv.org/api/query/search_query';
   // ref: https://info.arxiv.org/help/arxiv_identifier.html
   // e.g. (new id format: 2404.16782) | (old id format: hep-th/0702063)
   const parseArXivId = (str) => str.match(/(\d+\.\d+$)|((\w|-)+\/\d+$)/)?.[0];
 
   const paperId = parseArXivId(url);
-  const res = await fetch(ARXIV_API + '?id_list=' + paperId.toString());
+  const res = await fetch(ARXIV_API + '?id_list=' + paperId.toString(), {
+    method: 'GET',
+    mode: 'cors',
+    headers: {
+      Accept: 'application/atom+xml',
+    },
+  });
   if (res.status != 200) {
-    console.error('arXiv API request failed');
+    console.error('arXiv API request failed with status:', res.status);
     return;
   }
   const data = await res.text(); // TODO: error handling
@@ -142,6 +148,7 @@ const aclAnthologyParser = async (url) => {
 const urlParser = new URLParser();
 urlParser.addParser('https://openreview.net/', openReviewParser);
 urlParser.addParser('https://arxiv.org', arXivParser);
+urlParser.addParser('https://www.arxiv.org', arXivParser);
 urlParser.addParser('https://aclanthology.org', aclAnthologyParser);
 
 export default urlParser;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -11,7 +11,8 @@ import urlParser from './parsers.js';
 
 UIKit.use(Icons);
 
-const TEST_URL = 'https://arxiv.org/abs/2308.04079';
+//const TEST_URL = 'https://arxiv.org/abs/2308.04079';
+const TEST_URL = 'https://www.arxiv.org/abs/2508.20324';
 // const TEST_URL = 'https://aclanthology.org/2023.ijcnlp-main.1/';
 
 class UI {
@@ -90,7 +91,11 @@ class UI {
     return url?.startsWith('chrome-extension://') || false;
   }
   isArxivUrl(url) {
-    return url?.startsWith('https://arxiv.org') || false;
+    return (
+      url?.startsWith('https://arxiv.org') ||
+      url?.startsWith('https://www.arxiv.org') ||
+      false
+    );
   }
   isOpenReviewUrl(url) {
     return url?.startsWith('https://openreview.net/') || false;


### PR DESCRIPTION
## :cactus: Related Issues
- #21  

## 🔄 Changes

- Updated version from 1.4.0 to 1.4.1
- Added support for www.arxiv.org URLs in addition to arxiv.org
- Changed arXiv API endpoint from HTTP to HTTPS
- Added CORS headers and Accept header to arXiv API requests
- Improved error handling with status code logging
- Added host permissions for arxiv.org and www.arxiv.org domains
- Enhanced URL detection to support both arXiv domain formats
- Added pull request template

## ⚠️ Breaking Changes

- [x] None
- [ ] Yes
  - **Details:**

## 🎯 Motivation

- Improve security by migrating arXiv API to HTTPS
- Enhance usability by supporting more arXiv URL formats
- Improve pull request quality by introducing a template

## 🔍 Reproduction Steps

```bash
# Build and test
npm run build
npm run dev

# Run linter
npm run lint

# Package extension
npm run pack

# Test URLs
# https://arxiv.org/abs/2308.04079
# https://www.arxiv.org/abs/2508.20324
```

## ✅ Results

- Enhanced security with HTTPS migration for arXiv API
- Confirmed www.arxiv.org URLs are processed correctly
- Improved error handling makes debugging easier
- Consistent PR format ensured with pull request template

## 📝 Additional Notes

- Backward compatible changes that don't affect existing functionality
- Test URL changed to www.arxiv.org to verify new functionality
- Additional host permissions enable support for more arXiv domains

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches arXiv API calls to HTTPS with CORS headers, adds support and permissions for www.arxiv.org, and updates CI to Node 24/actions v4.
> 
> - **Parsing/Fetching**:
>   - arXiv: switch API to `https://export.arxiv.org/...` with CORS and `Accept: application/atom+xml` headers; improve error logging in `src/js/parsers.js`.
>   - URL support: handle `https://www.arxiv.org` in `src/js/parsers.js` and `src/js/popup.js`.
> - **Extension Manifest**:
>   - Bump version to `1.4.1` in `manifest.json` and `package.json`.
>   - Expand `host_permissions`: add `*://export.arxiv.org/*`, `*://arxiv.org/*`, `*://www.arxiv.org/*`.
> - **CI**:
>   - Upgrade workflow `build.yaml`: use `actions/checkout@v4`, `actions/setup-node@v4`, and Node `24.8.0`.
> - **Docs/Meta**:
>   - Update `CHANGELOG.md` for `1.4.1`.
>   - Add `.github/pull-request-template.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdf543f936648931e9ae76f5ccef4573304ae1cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->