### PR TITLE
Remove newlines in abstract

### DIFF
--- a/src/js/parsers.js
+++ b/src/js/parsers.js
@@ -44,7 +44,7 @@ const arXivParser = async (url) => {
   const entry = xmlData.querySelector('entry');
   const id = parseArXivId(entry.querySelector('id')?.textContent);
   const paperTitle = entry.querySelector('title').textContent;
-  const abst = entry.querySelector('summary').textContent;
+  const abst = entry.querySelector('summary').textContent.replace(/\n/g, ' ').trim();
   const authors = Array.from(entry.querySelectorAll('author')).map((author) => {
     return author.textContent.trim();
   });
@@ -82,7 +82,9 @@ const openReviewParser = async (url) => {
 
   const abst = xml
     .querySelector('meta[name="citation_abstract"]')
-    .getAttribute('content');
+    .getAttribute('content')
+    .replace(/\n/g, ' ')
+    .trim();
 
   const date = xml
     .querySelector('meta[name="citation_online_date"]')


### PR DESCRIPTION
## 🔄 Changes

Small change where I search for newlines and remove them in parsed abstract.

## ⚠️ Breaking Changes
- [x] None

## 🎯 Motivation

Sometimes the parsed text contains newlines mid-sentence. Since an abstract is supposed to be a single paragraph, I simply remove all newlines, replace them with a space, and trim extra spaces if necessary.
