### PR TITLE
update arxiv api

### DIFF
--- a/src/js/parsers.js
+++ b/src/js/parsers.js
@@ -19,7 +19,7 @@ class URLParser {
 }
 
 const arXivParser = async (url) => {
-  const ARXIV_API = 'https://export.arxiv.org/api/query/search_query';
+  const ARXIV_API = 'https://export.arxiv.org/api/query';
   // ref: https://info.arxiv.org/help/arxiv_identifier.html
   // e.g. (new id format: 2404.16782) | (old id format: hep-th/0702063)
   const parseArXivId = (str) => str.match(/(\d+\.\d+$)|((\w|-)+\/\d+$)/)?.[0];


### PR DESCRIPTION
## 🔄 Changes

Arxiv links stopped working, noticed this was because 
```
https://export.arxiv.org/api/query/search_query?id_list={id_list}
```
resulted in 404.

Fixed it by updating the API URL.
